### PR TITLE
Allow parameter filters to match multi-parameter attributes

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -29,7 +29,7 @@ module ActionController
     def require(key)
       self[key].presence || raise(ActionController::ParameterMissing.new(key))
     end
-    
+
     alias :required :require
 
     def permit(*filters)
@@ -39,6 +39,10 @@ module ActionController
         case filter
         when Symbol then
           params[filter] = self[filter] if has_key?(filter)
+
+          multi_param_keys_for(filter).each do |multi_filter|
+            params[multi_filter] = self[multi_filter]
+          end
         when Hash then
           self.slice(*filter.keys).each do |key, value|
             return unless value
@@ -96,6 +100,12 @@ module ActionController
         else
           yield object
         end
+      end
+
+      def multi_param_keys_for(filter)
+        keys.select { |key|
+          key.index("#{filter}(") == 0 && key.index(")") == key.length - 1
+        }
       end
   end
 

--- a/test/multi_parameter_attributes_test.rb
+++ b/test/multi_parameter_attributes_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'action_controller/parameters'
+
+class MultiParameterAttributesTest < ActiveSupport::TestCase
+  test "permitted multi-parameter attribute keys" do
+    params = ActionController::Parameters.new({
+      book: {
+        "shipped_at(1i)" => "2012",
+        "shipped_at(2i)" => "3",
+        "shipped_at(3i)" => "25",
+        "shipped_at(4i)" => "10",
+        "shipped_at(5i)" => "15",
+        "published_at(1i)"   => "1999",
+        "published_at(2i)"   => "2",
+        "published_at(3i)"   => "5"
+      }
+    })
+
+    permitted = params.permit book: [ :shipped_at ]
+
+    assert permitted.permitted?
+
+    assert_equal "2012", permitted[:book]["shipped_at(1i)"]
+    assert_equal "3", permitted[:book]["shipped_at(2i)"]
+    assert_equal "25", permitted[:book]["shipped_at(3i)"]
+    assert_equal "10", permitted[:book]["shipped_at(4i)"]
+    assert_equal "15", permitted[:book]["shipped_at(5i)"]
+
+    assert_nil permitted[:book]["published_at(1i)"]
+    assert_nil permitted[:book]["published_at(2i)"]
+    assert_nil permitted[:book]["published_at(3i)"]
+  end
+end


### PR DESCRIPTION
We're using the DateHelper in our application so in some places our permit list includes things like:

```
def book_params
  params[:book].permit( 
    :"published_at(1i)",                                                      
    :"published_at(2i)",                                                      
    :"published_at(3i)",                                                      
    :"published_at(4i)",                                                      
    :"published_at(5i)",
   ...
  )
end
```

This change matches multi-parameter attributes based upon the head of the key so you can just include `:published_at` in the above example.
