### PR TITLE
Support fields_for attributes, which may have numeric symbols as hash keys

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -29,7 +29,7 @@ module ActionController
     def require(key)
       self[key].presence || raise(ActionController::ParameterMissing.new(key))
     end
-    
+
     alias :required :require
 
     def permit(*filters)
@@ -93,6 +93,11 @@ module ActionController
       def each_element(object)
         if object.is_a?(Array)
           object.map { |el| yield el }.compact
+        # fields_for on an array of records uses numeric hash keys
+        elsif object.is_a?(Hash) && object.keys.all? { |k| k =~ /\A\d+\z/ }
+          hash = object.class.new
+          object.each { |k,v| hash[k] = yield v }
+          hash
         else
           yield object
         end

--- a/test/nested_parameters_test.rb
+++ b/test/nested_parameters_test.rb
@@ -92,4 +92,22 @@ class NestedParametersTest < ActiveSupport::TestCase
     permitted = params.permit book: { genre: :type }
     assert_nil permitted[:book][:genre]
   end
+
+  test "fields_for_style_nested_params" do
+    params = ActionController::Parameters.new({
+      book: {
+        authors_attributes: {
+          :'0' => { name: 'William Shakespeare', age_of_death: '52' },
+          :'1' => { name: 'Unattributed Assistant' }
+        }
+      }
+    })
+    permitted = params.permit book: { authors_attributes: [ :name ] }
+
+    assert_not_nil permitted[:book][:authors_attributes]['0']
+    assert_not_nil permitted[:book][:authors_attributes]['1']
+    assert_nil permitted[:book][:authors_attributes]['0'][:age_of_death]
+    assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['0'][:name]
+    assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['1'][:name]
+  end
 end


### PR DESCRIPTION
fields_for will use numeric hash keys when used on a collection of records. Ex:

``` ruby
  # ...
  @company.users.new
  # ...
```

``` erb
  <%= f.fields_for :users %>
```

This patch will treat this hash similarly to an array. The hash structure is not mutated so there should be no side effects, and it only affects hashes in which all keys are numeric.

Relates to #24 and closes #16.

This patch may be seen as a work in progress. There may be better ways to implement this so feedback is of course welcome.
