### PR TITLE
Support fields_for attributes, which may have negative numeric symbols as hash keys

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -94,7 +94,7 @@ module ActionController
         if object.is_a?(Array)
           object.map { |el| yield el }.compact
         # fields_for on an array of records uses numeric hash keys
-        elsif object.is_a?(Hash) && object.keys.all? { |k| k =~ /\A\d+\z/ }
+        elsif object.is_a?(Hash) && object.keys.all? { |k| k =~ /\A-?\d+\z/ }
           hash = object.class.new
           object.each { |k,v| hash[k] = yield v }
           hash

--- a/test/nested_parameters_test.rb
+++ b/test/nested_parameters_test.rb
@@ -110,4 +110,22 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['0'][:name]
     assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['1'][:name]
   end
+
+  test "fields_for_style_nested_params with negative numbers" do
+    params    = ActionController::Parameters.new({
+      book: {
+        authors_attributes: {
+          :'-1' => {name: 'William Shakespeare', age_of_death: '52'},
+          :'-2' => {name: 'Unattributed Assistant'}
+        }
+      }
+    })
+    permitted = params.permit book: {authors_attributes: [:name]}
+
+    assert_not_nil permitted[:book][:authors_attributes]['-1']
+    assert_not_nil permitted[:book][:authors_attributes]['-2']
+    assert_nil permitted[:book][:authors_attributes]['-1'][:age_of_death]
+    assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['-1'][:name]
+    assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['-2'][:name]
+  end
 end


### PR DESCRIPTION
As for positive numbers, I sometime need negative numbers as hash keys.
