### PR TITLE
Adds Parameter#recursive_permit! with tests

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -26,6 +26,15 @@ module ActionController
       self
     end
 
+    def recursive_permit!
+      each_pair do |key, value|
+        convert_hashes_to_parameters(key, value)
+        self[key].recursive_permit! if self[key].respond_to? :recursive_permit!
+      end
+
+      permit!
+    end
+
     def require(key)
       self[key].presence || raise(ActionController::ParameterMissing.new(key))
     end

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -58,4 +58,11 @@ class ParametersTaintTest < ActiveSupport::TestCase
     @params.permit!
     assert_equal @params.permitted?, @params.dup.permitted?
   end
+
+  test "recursive permit works" do
+    @params.recursive_permit!
+    assert @params.permitted?
+    assert @params[:person].permitted?
+    assert @params[:person][:name].permitted?
+  end
 end


### PR DESCRIPTION
When building apps with admin-only authenticated namespaces we often found strong_parameters redundant. However, since we had already included `ActiveModel::ForbiddenAttributesProtection` in our models we were forced to implement it anyway. This update introduces a `Parameter#recursive_permit!` option that crawls the params hash and `#permit!`s any nested hashes. It is well suited for use in namespaced application controllers like so:

``` ruby
class Admin::ApplicationController < ::ApplicationController
  before_filter :permit_params

  private

  def permit_params
    params.recursive_permit!
  end
end
```
