### PR TITLE
Don't check attr_protected attrs if we use strong_params

### DIFF
--- a/lib/active_model/forbidden_attributes_protection.rb
+++ b/lib/active_model/forbidden_attributes_protection.rb
@@ -4,11 +4,9 @@ module ActiveModel
 
   module ForbiddenAttributesProtection
     def sanitize_for_mass_assignment(new_attributes, options = {})
-      if !new_attributes.respond_to?(:permitted?) || new_attributes.permitted?
-        super
-      else
-        raise ActiveModel::ForbiddenAttributes
-      end
+      return super if !new_attributes.respond_to?(:permitted?)
+      return new_attributes if new_attributes.permitted?
+      raise ActiveModel::ForbiddenAttributes
     end
   end
 end

--- a/test/active_model_mass_assignment_taint_protection_test.rb
+++ b/test/active_model_mass_assignment_taint_protection_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Person
   include ActiveModel::MassAssignmentSecurity
   include ActiveModel::ForbiddenAttributesProtection
-  
+
   public :sanitize_for_mass_assignment
 end
 
@@ -20,11 +20,25 @@ class ActiveModelMassUpdateProtectionTest < ActiveSupport::TestCase
         Person.new.sanitize_for_mass_assignment(ActionController::Parameters.new(a: "b").permit(:a)))
     end
   end
-  
+
   test "regular attributes should still be allowed" do
     assert_nothing_raised do
       assert_equal({ a: "b" },
         Person.new.sanitize_for_mass_assignment(a: "b"))
+    end
+  end
+
+  test "regular methods should be allowed with attr_accessible set to nil" do
+    Person.attr_accessible(nil)
+
+    assert_nothing_raised do
+      assert_equal({},
+        Person.new.sanitize_for_mass_assignment(a: "b"))
+    end
+
+    assert_nothing_raised do
+      assert_equal({ "a" => "b" },
+                   Person.new.sanitize_for_mass_assignment(ActionController::Parameters.new(a: "b").permit(:a)))
     end
   end
 end


### PR DESCRIPTION
Skip using the `MassAssignmentSecurity::sanitize_for_mass_assignment` if we use the strong_params.

The problem was 

```
class User < AR:Base
  def custom_name=(val) #There are no attribute with custom_name
  end
end
```

And I need always use `without_protection` option for the `assignment_attributes` or `attr_accessible`, even when use permitted attributes. I think it is not corrected, when I have already permitted this attribute.