### PR TITLE
Fix Regexp.escape(filter) for Ruby 1.8.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -44,7 +44,7 @@ module ActionController
         case filter
         when Symbol, String then
           params[filter] = self[filter] if has_key?(filter)
-          keys.grep(/\A#{Regexp.escape(filter)}\(\d+[if]?\)\z/).each { |key| params[key] = self[key] }
+          keys.grep(/\A#{Regexp.escape(filter.to_s)}\(\d+[if]?\)\z/).each { |key| params[key] = self[key] }
         when Hash then
           self.slice(*filter.keys).each do |key, value|
             return unless value


### PR DESCRIPTION
Fixes an issue introduced in #39 for Ruby 1.8 with `Regexp.escape`.

Ruby 1.8 `Regexp.escape` does not accept symbols like Ruby 1.9, so explicitly call `#to_s` on `filter` to avoid the "can't convert Symbol to String" exception.
