### PR TITLE
Permitted should be sticky when calling slice

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -77,7 +77,9 @@ module ActionController
     end
 
     def slice(*keys)
-      self.class.new(super)
+      self.class.new(super).tap do |new_instance|
+        new_instance.instance_variable_set :@permitted, @permitted
+      end
     end
 
     def dup

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -22,7 +22,7 @@ class ParametersTaintTest < ActiveSupport::TestCase
     end
   end
 
-  test "permitted is sticky on accessors" do
+  test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
 
@@ -33,12 +33,12 @@ class ParametersTaintTest < ActiveSupport::TestCase
     assert !@params.values_at(:person).first.permitted?
   end
 
-  test "permitted is sticky on mutators" do
+  test "not permitted is sticky on mutators" do
     assert !@params.delete_if { |k, v| k == "person" }.permitted?
     assert !@params.keep_if { |k, v| k == "person" }.permitted?
   end
 
-  test "permitted is sticky beyond merges" do
+  test "not permitted is sticky beyond merges" do
     assert !@params.merge(:a => "b").permitted?
   end
 

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -26,7 +26,7 @@ class ParametersTaintTest < ActiveSupport::TestCase
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
 
-    @params.each { |key, value| assert(value.permitted?) if key == :person }
+    @params.each { |key, value| assert(!value.permitted?) if key == "person" }
 
     assert !@params.fetch(:person).permitted?
 
@@ -34,8 +34,8 @@ class ParametersTaintTest < ActiveSupport::TestCase
   end
 
   test "permitted is sticky on mutators" do
-    assert !@params.delete_if { |k, v| k == :person }.permitted?
-    assert !@params.keep_if { |k, v| k == :person }.permitted?
+    assert !@params.delete_if { |k, v| k == "person" }.permitted?
+    assert !@params.keep_if { |k, v| k == "person" }.permitted?
   end
 
   test "permitted is sticky beyond merges" do

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -34,13 +34,37 @@ class ParametersTaintTest < ActiveSupport::TestCase
     assert !@params.values_at(:person).first.permitted?
   end
 
+  test "permitted is sticky on accessors" do
+    @params.permit!
+    assert @params.slice(:person).permitted?
+    assert @params[:person][:name].permitted?
+    assert @params[:person].except(:name).permitted?
+
+    @params.each { |key, value| assert(value.permitted?) if key == "person" }
+
+    assert @params.fetch(:person).permitted?
+
+    assert @params.values_at(:person).first.permitted?
+  end
+
   test "not permitted is sticky on mutators" do
     assert !@params.delete_if { |k, v| k == "person" }.permitted?
     assert !@params.keep_if { |k, v| k == "person" }.permitted?
   end
 
+  test "permitted is sticky on mutators" do
+    @params.permit!
+    assert @params.delete_if { |k, v| k == "person" }.permitted?
+    assert @params.keep_if { |k, v| k == "person" }.permitted?
+  end
+
   test "not permitted is sticky beyond merges" do
     assert !@params.merge(:a => "b").permitted?
+  end
+
+  test "permitted is sticky beyond merges" do
+    @params.permit!
+    assert @params.merge(:a => "b").permitted?
   end
 
   test "modifying the parameters" do

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -49,13 +49,13 @@ class ParametersTaintTest < ActiveSupport::TestCase
 
   test "not permitted is sticky on mutators" do
     assert !@params.delete_if { |k, v| k == "person" }.permitted?
-    assert !@params.keep_if { |k, v| k == "person" }.permitted?
+    assert !@params.keep_if { |k, v| k == "person" }.permitted? if @params.respond_to?(:keep_if)
   end
 
   test "permitted is sticky on mutators" do
     @params.permit!
     assert @params.delete_if { |k, v| k == "person" }.permitted?
-    assert @params.keep_if { |k, v| k == "person" }.permitted?
+    assert @params.keep_if { |k, v| k == "person" }.permitted? if @params.respond_to?(:keep_if)
   end
 
   test "not permitted is sticky beyond merges" do

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -25,6 +25,7 @@ class ParametersTaintTest < ActiveSupport::TestCase
   test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?
+    assert !@params[:person].except(:name).permitted?
 
     @params.each { |key, value| assert(!value.permitted?) if key == "person" }
 


### PR DESCRIPTION
This pull request solves 3 different things:
1. Some of the parameters_taint tests were broken. Fixed in f2a639f7423a63bb2ccbca3328ed649ab4f2d9c4
2. The "permitted is sticky" tests are actually testing that "tainted is sticky". "Tainted" seems to not be used anymore, so I changed their titles to "not permitted is sticky" in 8809ddedf3d7baed983513cc08590e3905f737f1 – and added a test for #except in 814b6cfaf44f5739d32abccb281400738a0333ba
3. I made a set of new "permitted is sticky" tests, basically inverted copies of the existing tests, only testing on a `permitted` object: c0f35dd42a979b2e22d9a8e2485ece3c7ec72984 – with the #slice bug fixed in 0b32721d72bb301c2884cda4001e6242c897fe5f

Fixes #57
