### PR TITLE
Fixes issue where permit returns params.permitted == true if there are no matches to the filters

### DIFF
--- a/test/active_model_mass_assignment_taint_protection_test.rb
+++ b/test/active_model_mass_assignment_taint_protection_test.rb
@@ -14,6 +14,12 @@ class ActiveModelMassUpdateProtectionTest < ActiveSupport::TestCase
     end
   end
   
+  test "forbidden attributes cannot be used for mass updating when there are some matches" do
+    assert_raises(ActiveModel::ForbiddenAttributes) do
+      Person.new.sanitize_for_mass_assignment(ActionController::Parameters.new(:a => "b", :c => 'd').permit(:c))
+    end
+  end
+  
   test "attributes cannot be used for mass updating when nothing permitted" do
     assert_raises(ActiveModel::ForbiddenAttributes) do
       Person.new.sanitize_for_mass_assignment(ActionController::Parameters.new(:a => "b"))

--- a/test/multi_parameter_attributes_test.rb
+++ b/test/multi_parameter_attributes_test.rb
@@ -20,7 +20,7 @@ class MultiParameterAttributesTest < ActiveSupport::TestCase
 
     permitted = params.permit :book => [ :shipped_at, :price ]
 
-    assert permitted.permitted?
+    assert !permitted.permitted?, 'should not be true as published_at is not in permit'
 
     assert_equal "2012", permitted[:book]["shipped_at(1i)"]
     assert_equal "3", permitted[:book]["shipped_at(2i)"]

--- a/test/nested_parameters_test.rb
+++ b/test/nested_parameters_test.rb
@@ -22,7 +22,7 @@ class NestedParametersTest < ActiveSupport::TestCase
 
     permitted = params.permit :book => [ :title, { :authors => [ :name ] }, { :details => :pages } ]
 
-    assert permitted.permitted?
+    assert !permitted.permitted?, 'should not be true as not all param keys are in permit'
     assert_equal "Romeo and Juliet", permitted[:book][:title]
     assert_equal "William Shakespeare", permitted[:book][:authors][0][:name]
     assert_equal "Christopher Marlowe", permitted[:book][:authors][1][:name]


### PR DESCRIPTION
This relates to issue https://github.com/rails/strong_parameters/issues/71 

```
Person.new.sanitize_for_mass_assignment(ActionController::Parameters.new(:a => "b").permit(:c))
```

In tests this should raise an error, but it doesn't because permit always return an object with @permitted set as true
