### PR TITLE
Simplified the README example.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,9 +15,9 @@ In addition, parameters can be marked as required and flow through a predefined 
       # it'll raise a ActionController::MissingParameter exception, which will get caught by
       # ActionController::Base and turned into that 400 Bad Request reply.
       def update
-        redirect_to current_account.people.find(params[:id]).tap { |person|
-          person.update_attributes!(person_params)
-        }
+        person = current_account.people.find(params[:id])
+        person.update(person_params)
+        redirect_to person
       end
 
       private


### PR DESCRIPTION
Instead of getting tricky with .tap, we should be keeping it simple.

```
def update
  redirect_to current_account.people.find(params[:id]).tap { |person|
    person.update_attributes!(person_params)
  }
end
```

That's the current README example. 

This can (and probably should) be simplified to

```
def update
  person = current_account.people.find(params[:id])
  person.update(person_params)
  redirect_to person
end
```

They do the exact same thing from what I can tell.

(thanks @steveklabnik for helping me figure this out)
