### PR TITLE
Fix the railtie

### DIFF
--- a/lib/strong_parameters/railtie.rb
+++ b/lib/strong_parameters/railtie.rb
@@ -8,8 +8,8 @@ module StrongParameters
       config.generators.scaffold_controller = :strong_parameters_controller
     end
 
-    initializer "strong_parameters.config", :before => "active_controller.set_configs" do |app| 
-      ActionController::Parameters.action_on_unpermitted_parameters = options.delete(:action_on_unpermitted_parameters) do
+    initializer "strong_parameters.config", :before => "action_controller.set_configs" do |app|
+      ActionController::Parameters.action_on_unpermitted_parameters = app.config.action_controller.delete(:action_on_unpermitted_parameters) do
         (Rails.env.test? || Rails.env.development?) ? :log : false
       end
     end


### PR DESCRIPTION
The commit ae3826f339509638b2b31f608c3eeb3136946aa8 to raise or log unpermitted parameters has broken the railtie.
- The initializer before which the config parameter should have been set was not properly named.
- the `options` variable name isn't available in 3.2. We need to call `app.config`.

This fixes the railtie making it possible to run the edge version of the repository with 3.2.
