### PR TITLE
Rack::Test::UploadedFile is a permitted scalar

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ Given
 
 the key +:id+ will pass the whitelisting if it appears in +params+ and it has a permitted scalar value associated. Otherwise the key is going to be filtered out, so arrays, hashes, or any other objects cannot be injected.
 
-The permitted scalar types are +String+, +Symbol+, +NilClass+, +Numeric+, +TrueClass+, +FalseClass+, +Date+, +Time+, +DateTime+, +StringIO+, +IO+, and +ActionDispatch::Http::UploadedFile+.
+The permitted scalar types are +String+, +Symbol+, +NilClass+, +Numeric+, +TrueClass+, +FalseClass+, +Date+, +Time+, +DateTime+, +StringIO+, +IO+, +ActionDispatch::Http::UploadedFile+ and +Rack::Test::UploadedFile+.
 
 To declare that the value in +params+ must be an array of permitted scalar values map the key to an empty array:
 

--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -143,6 +143,7 @@ module ActionController
         StringIO,
         IO,
         ActionDispatch::Http::UploadedFile,
+        Rack::Test::UploadedFile,
       ]
 
       def permitted_scalar?(value)

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -27,7 +27,7 @@ class NestedParametersTest < ActiveSupport::TestCase
     values += [0, 1.0, 2**128, BigDecimal.new('1')]
     values += [true, false]
     values += [Date.today, Time.now, DateTime.now]
-    values += [StringIO.new, STDOUT, ActionDispatch::Http::UploadedFile.new(:tempfile => __FILE__)]
+    values += [StringIO.new, STDOUT, ActionDispatch::Http::UploadedFile.new(:tempfile => __FILE__), Rack::Test::UploadedFile.new(__FILE__)]
 
     values.each do |value|
       params = ActionController::Parameters.new(:id => value)


### PR DESCRIPTION
Fixes #105

According to [this](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/test_case.rb#L490), Rack::Test::UploadedFile is an acceptable type, so strong_parameters should allow it.
