### PR TITLE
Add very basic initializer to enforce system wide

### DIFF
--- a/lib/generators/rails/strong_parameters_initializer_generator.rb
+++ b/lib/generators/rails/strong_parameters_initializer_generator.rb
@@ -1,0 +1,15 @@
+module Rails
+  module Generators
+    class StrongParametersInitializerGenerator < Rails::Generators::Base
+      desc "Creates an initializer file to enforce strong parameters on all ActiveRecord models"
+
+      def create_initializer_file
+        create_file "config/initializers/strong_parameters.rb", initializer_content
+      end
+
+      def initializer_content
+        "ActiveRecord::Base.send(:include, ActiveModel::ForbiddenAttributesProtection)\n"
+      end
+    end
+  end
+end

--- a/test/initializer_generator_test.rb
+++ b/test/initializer_generator_test.rb
@@ -1,0 +1,18 @@
+require 'rails/generators/test_case'
+require 'generators/rails/strong_parameters_initializer_generator'
+
+class StrongParametersInitializerGeneratorTest < Rails::Generators::TestCase
+  tests Rails::Generators::StrongParametersInitializerGenerator
+  destination File.expand_path("../tmp", File.dirname(__FILE__))
+  setup :prepare_destination
+
+  def test_initializer_content
+    Rails.stubs(:application).returns(nil)
+    run_generator
+
+    assert_file "config/initializers/strong_parameters.rb" do |content|
+      init_code = 'ActiveRecord::Base.send(:include, ActiveModel::ForbiddenAttributesProtection)'
+      assert_match init_code, content
+    end
+  end
+end


### PR DESCRIPTION
I've added the config initializer referenced in the README on every
Rails 3.x project I've deployed StrongParameters in, so figured
this is useful.
