### PR TITLE
Allow multiple keys in call to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ This declaration whitelists the `name`, `emails` and `friends` attributes. It is
 
 Thanks to Nick Kallen for the permit idea!
 
+## Requiring multiple values
+
+In some cases you might want to require several parameters to be present before proceeding, such as for an API where the params might be a flat hash. You can use `require` to do this:
+
+``` ruby
+params.require(:username, :password).permit(:version)
+```
+
+When used with multiple inputs `require` raises a `ActionController::MissingParameter` error with *all* the missing attributes specified in the message. If no values are missing the params hash is returned unmodified.
+
 ## Handling of Unpermitted Keys
 
 By default parameter keys that are not explicitly permitted will be logged in the development and test environment. In other environments these parameters will simply be filtered out and ignored.

--- a/test/action_controller_required_params_test.rb
+++ b/test/action_controller_required_params_test.rb
@@ -25,6 +25,6 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
 
   test "missing parameters will be mentioned in the return" do
     post :create, { :magazine => { :name => "Mjallo!" } }
-    assert_equal "Required parameter missing: book", response.body
+    assert_match "book", response.body
   end
 end

--- a/test/log_on_unpermitted_params_test.rb
+++ b/test/log_on_unpermitted_params_test.rb
@@ -16,7 +16,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
       :fishing => "Turnips"
     })
 
-    assert_logged("Unpermitted parameters: fishing") do
+    assert_logged("Unpermitted parameter(s): fishing") do
       params.permit(:book => [:pages])
     end
   end
@@ -26,7 +26,7 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
       :book => { :pages => 65, :title => "Green Cats and where to find then." }
     })
 
-    assert_logged("Unpermitted parameters: title") do
+    assert_logged("Unpermitted parameter(s): title") do
       params.permit(:book => [:pages])
     end
   end

--- a/test/parameters_require_test.rb
+++ b/test/parameters_require_test.rb
@@ -7,4 +7,29 @@ class ParametersRequireTest < ActiveSupport::TestCase
       ActionController::Parameters.new(:person => {}).require(:person)
     end
   end
+
+  test "permit multiple required parameters" do
+    params = ActionController::Parameters.new(:username => 'user', :password => '<3<3<3<3')
+    assert_nothing_raised(ActionController::ParameterMissing) do
+      params.require(:username, :password)
+    end
+
+    assert params.has_key?(:username)
+    assert params.has_key?(:password)
+  end
+
+  test "multiple required parameters must be present not merely not nil" do
+    params = ActionController::Parameters.new(:username => '', :password => nil)
+    assert_raises(ActionController::ParameterMissing) do
+      params.require(:username, :password)
+    end
+  end
+
+  test "all parameters are returned after required with multiple parameters" do
+    params = ActionController::Parameters.new(:username => 'user', :password => '<3<3<3<3', :version => 1)
+
+    params.require(:username, :password)
+
+    assert params.has_key?(:version)
+  end
 end


### PR DESCRIPTION
The current version of require takes only one key and returns the value for that key (or raises if it's not present). I added code to support calls like this:

``` ruby
params = ActionController::Parameters.new(:username => 'user', :password => '<3<3<3<3', :version => 1)
params.require(:username, :password)
# => {"username"=>"user", "password"=>"<3<3<3<3", "version"=>1}
```

It still throws if the required parameters are missing, including all the missing keys:

``` ruby
params = ActionController::Parameters.new(:version => 1)
params.require(:username, :password)
# => "Required parameter(s) missing: username, password"
```

Since it's not reasonable to return the keys values in this case the method simply returns self instead. This allows for other methods to be chained as expected.

Basically it allows you to do:

``` ruby
params.require(:user, :post).permit(:user => [:name], :post => [:content])
```

instead of:

``` ruby
params.require(:user).permit(:name)
params.require(:post).permit(:content)
```

And for the cases where you don't have the normal, nested hashes (such as in my case of an API accepting a non nested list of parameters) you won't have to do one call to permit for every required parameter in the API call.

I don't know if this is interesting for inclusion, it's not really an edge case, but not the most common case either, nor if the approach presented here is the best/a good enough one ... So comments on the code are most welcome.
