### PR TITLE
Permitting arrays within a hash

### DIFF
--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -291,4 +291,22 @@ class NestedParametersTest < ActiveSupport::TestCase
 
     assert_filtered_out permitted[:book][:authors_attributes]['-1'], :age_of_death
   end
+
+  test "fields_for_style_nested_params with nested arrays" do
+    params = ActionController::Parameters.new({
+      :book => {
+        :authors_attributes => {
+          :'0' => ['William Shakespeare', '52'],
+          :'1' => ['Unattributed Assistant']
+        }
+      }
+    })
+    permitted = params.permit :book => { :authors_attributes => { :'0' => [], :'1' => [] } }
+
+    assert_not_nil permitted[:book][:authors_attributes]['0']
+    assert_not_nil permitted[:book][:authors_attributes]['1']
+    assert_nil permitted[:book][:authors_attributes]['2']
+    assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['0'][0]
+    assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['1'][0]
+  end
 end


### PR DESCRIPTION
Hi,

After digging the strong_parameters code and trying several filters I can't find a way to permit something like this:

``` ruby
{
  modification: {
    opening_hours: {
      "0" => ["08:00 18:00"],
      "1" => ["08:00 18:00"]
    }
  }
}
```

Is there a specific filter that would allow this ? I tried the following:

``` ruby
params.require(:modification).permit(:opening_hours)
params.require(:modification).permit(opening_hours: [])
params.require(:modification).permit(opening_hours: {})
params.require(:modification).permit(opening_hours: ['0'])
params.require(:modification).permit(opening_hours: { '0' => [] })
```

The only thing I get so far is this:

``` ruby
{
  opening_hours: {
    "0" => nil,
    "1" => nil
  }
}
```

Is there a solution here ?
Thanks :)
