### PR TITLE
Add support for specifying the log level instead of relying on the hard-coded log level of info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Thanks to Nick Kallen for the permit idea!
 
 By default parameter keys that are not explicitly permitted will be logged in the development and test environment. In other environments these parameters will simply be filtered out and ignored.
 
-Additionally, this behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised.
+Additionally, this behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:raise` an exception will be raised, if set to `:log` the unpermitted attributes will be logged with the `info` log level. You can further customize the log level by setting the `config.action_controller.action_on_unpermitted_parameters` property to `:log_debug`, `:log_warn`, `:log_error` or `:log_fatal` to get the corrisponding `debug`, `warn`, `error` and `fatal` log levels. Setting the property to `:log_info` is identical to setting it to `:log`.
 
 ## Use Outside of Controllers
 

--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -217,9 +217,11 @@ module ActionController
         unpermitted_keys = unpermitted_keys(params)
 
         if unpermitted_keys.any?  
-          case self.class.action_on_unpermitted_parameters  
+          case action = self.class.action_on_unpermitted_parameters
           when :log  
             ActionController::Base.logger.info "Unpermitted parameters: #{unpermitted_keys.join(", ")}"
+          when :log_debug, :log_info, :log_warn, :log_error, :log_fatal
+            ActionController::Base.logger.send(action.to_s[4..-1], "Unpermitted parameters: #{unpermitted_keys.join(", ")}")
           when :raise  
             raise ActionController::UnpermittedParameters.new(unpermitted_keys)  
           end  

--- a/test/log_on_unpermitted_params_test.rb
+++ b/test/log_on_unpermitted_params_test.rb
@@ -2,32 +2,63 @@ require 'test_helper'
 require 'action_controller/parameters'
 
 class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
-  def setup
-    ActionController::Parameters.action_on_unpermitted_parameters = :log
-  end
 
   def teardown
     ActionController::Parameters.action_on_unpermitted_parameters = false
   end
 
-  test "logs on unexpected params" do
+  test "logs on unexpected params when action is set to :log " do
     params = ActionController::Parameters.new({
       :book => { :pages => 65 },
       :fishing => "Turnips"
     })
 
+    ActionController::Parameters.action_on_unpermitted_parameters = :log
     assert_logged("Unpermitted parameters: fishing") do
       params.permit(:book => [:pages])
     end
   end
 
-  test "logs on unexpected nested params" do
+  test "logs on unexpected params when action is set to log with a log level" do
+    params = ActionController::Parameters.new({
+      :book => { :pages => 65 },
+      :fishing => "Turnips"
+    })
+
+    ActionController::Parameters.action_on_unpermitted_parameters = :log
+    assert_logged("Unpermitted parameters: fishing") do
+      params.permit(:book => [:pages])
+    end
+
+    [:log_debug, :log_info, :log_warn, :log_error, :log_fatal].each do |log_level|
+      ActionController::Parameters.action_on_unpermitted_parameters = log_level
+      assert_logged("Unpermitted parameters: fishing") do
+        params.permit(:book => [:pages])
+      end
+    end
+  end
+
+  test "logs on unexpected nested params when action is set to :log" do
+    ActionController::Parameters.action_on_unpermitted_parameters = :log
     params = ActionController::Parameters.new({
       :book => { :pages => 65, :title => "Green Cats and where to find then." }
     })
 
     assert_logged("Unpermitted parameters: title") do
       params.permit(:book => [:pages])
+    end
+  end
+
+  test "logs on unexpected nested params when action is set to log with a log level" do
+    params = ActionController::Parameters.new({
+      :book => { :pages => 65, :title => "Green Cats and where to find then." }
+    })
+
+    [:log_debug, :log_info, :log_warn, :log_error, :log_fatal].each do |log_level|
+      assert_logged("Unpermitted parameters: title") do
+        ActionController::Parameters.action_on_unpermitted_parameters = log_level
+        params.permit(:book => [:pages])
+      end
     end
   end
 


### PR DESCRIPTION
Allow specifying :log_debug, :log_info, :log_warn, :log_error and :log_fatal to get different log levels from the hard coded info log level when specifying :log.

This will allow users with production logs set to levels higher than info use the logging feature.
