### PR TITLE
remove mocha to fix travis failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,9 +29,6 @@ GEM
     erubis (2.6.6)
       abstract (>= 1.0.0)
     i18n (0.5.0)
-    metaclass (0.0.1)
-    mocha (0.12.10)
-      metaclass (~> 0.0.1)
     rack (1.2.8)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -51,7 +48,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mocha (~> 0.12.0)
   rake
   rdoc (>= 4.0.0)
   strong_parameters!

--- a/strong_parameters.gemspec
+++ b/strong_parameters.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", "~> 3.0"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "mocha", "~> 0.12.0"
 end

--- a/test/controller_generator_test.rb
+++ b/test/controller_generator_test.rb
@@ -8,7 +8,6 @@ class StrongParametersControllerGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
   def test_controller_content
-    Rails.stubs(:application).returns(nil)
     run_generator
 
     assert_file "app/controllers/users_controller.rb" do |content|

--- a/test/gemfiles/Gemfile.rails-3.0.x.lock
+++ b/test/gemfiles/Gemfile.rails-3.0.x.lock
@@ -30,9 +30,6 @@ GEM
       abstract (>= 1.0.0)
     i18n (0.5.0)
     json (1.7.5)
-    metaclass (0.0.1)
-    mocha (0.12.7)
-      metaclass (~> 0.0.1)
     rack (1.2.5)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -56,7 +53,6 @@ PLATFORMS
 DEPENDENCIES
   actionpack (~> 3.0.0)
   activemodel (~> 3.0.0)
-  mocha (~> 0.12.0)
   railties (~> 3.0.0)
   rake
   strong_parameters!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,6 @@ Rails.application = FakeApplication
 Rails.configuration.action_controller = ActiveSupport::OrderedOptions.new
 
 require 'strong_parameters'
-require 'mocha'
 
 module ActionController
   SharedTestRoutes = ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
I noticed travis CI failures because of the mocha gem, which is not in use. I removed it completely to fix the builds.
