### PR TITLE
Use the instrumentation framework to instrument unpermitted params.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -218,8 +218,9 @@ module ActionController
 
         if unpermitted_keys.any?  
           case self.class.action_on_unpermitted_parameters  
-          when :log  
-            ActionController::Base.logger.info "Unpermitted parameters: #{unpermitted_keys.join(", ")}"
+          when :log
+            name = "unpermitted_parameters.action_controller"
+            ActiveSupport::Notifications.instrument(name, :keys => unpermitted_keys)
           when :raise  
             raise ActionController::UnpermittedParameters.new(unpermitted_keys)  
           end  

--- a/lib/strong_parameters.rb
+++ b/lib/strong_parameters.rb
@@ -1,3 +1,4 @@
 require 'action_controller/parameters'
 require 'active_model/forbidden_attributes_protection'
 require 'strong_parameters/railtie'
+require 'strong_parameters/log_subscriber'

--- a/lib/strong_parameters/log_subscriber.rb
+++ b/lib/strong_parameters/log_subscriber.rb
@@ -1,0 +1,14 @@
+module StrongParameters
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def unpermitted_parameters(event)
+      unpermitted_keys = event.payload[:keys]
+      debug("Unpermitted parameters: #{unpermitted_keys.join(", ")}")
+    end
+
+    def logger
+      ActionController::Base.logger
+    end
+  end
+end
+
+StrongParameters::LogSubscriber.attach_to :action_controller


### PR DESCRIPTION
Similarly to rails/rails, use the instrumentation framework to instrument unpermitted params. The event name is compatible with this in rails/rails to allow easy migration to rails 4.0
