### PR TITLE
Adds request information to logged message and to the raised exception.

### DIFF
--- a/lib/strong_parameters/log_subscriber.rb
+++ b/lib/strong_parameters/log_subscriber.rb
@@ -2,7 +2,8 @@ module StrongParameters
   class LogSubscriber < ActiveSupport::LogSubscriber
     def unpermitted_parameters(event)
       unpermitted_keys = event.payload[:keys]
-      debug("Unpermitted parameters: #{unpermitted_keys.join(", ")}")
+      request_info = event.payload[:request_info]
+      debug("Unpermitted parameters: #{unpermitted_keys.join(", ")} in #{request_info[:controller]}##{request_info[:action]}")
     end
 
     def logger

--- a/test/action_controller_required_params_test.rb
+++ b/test/action_controller_required_params_test.rb
@@ -25,6 +25,6 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
 
   test "missing parameters will be mentioned in the return" do
     post :create, { :magazine => { :name => "Mjallo!" } }
-    assert_equal "Required parameter missing: book", response.body
+    assert_equal "Required parameter missing: book in books#create", response.body
   end
 end

--- a/test/log_on_unpermitted_params_test.rb
+++ b/test/log_on_unpermitted_params_test.rb
@@ -13,20 +13,35 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
   test "logs on unexpected params" do
     params = ActionController::Parameters.new({
       :book => { :pages => 65 },
-      :fishing => "Turnips"
+      :fishing => "Turnips",
+      :controller => "books",
+      :action => "create"
     })
 
-    assert_logged("Unpermitted parameters: fishing") do
+    assert_logged("Unpermitted parameters: fishing in books#create") do
       params.permit(:book => [:pages])
     end
   end
 
   test "logs on unexpected nested params" do
     params = ActionController::Parameters.new({
-      :book => { :pages => 65, :title => "Green Cats and where to find then." }
+      :book => { :pages => 65, :title => "Green Cats and where to find then.",
+      :controller => "books",
+      :action => "update"}
     })
 
-    assert_logged("Unpermitted parameters: title") do
+    assert_logged("Unpermitted parameters: title in books#update") do
+      params.permit(:book => [:pages])
+    end
+  end
+
+   test "logs on unexpected params even when no controller or action info is supplied" do
+    params = ActionController::Parameters.new({
+      :book => { :pages => 65 },
+      :fishing => "Turnips"
+    })
+
+    assert_logged("Unpermitted parameters: fishing in ") do
       params.permit(:book => [:pages])
     end
   end


### PR DESCRIPTION
Before: `Unpermitted parameters: title`
 After:     `Unpermitted parameters: title in books#update`

This is helpful since when logging is set to warn or error there is no other information in the logs that allows matching the offending request with a specific action.
