### PR TITLE
handle UnpermittedParameters as bad request

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -239,6 +239,9 @@ module ActionController
       rescue_from(ActionController::ParameterMissing) do |parameter_missing_exception|
         render :text => "Required parameter missing: #{parameter_missing_exception.param}", :status => :bad_request
       end
+      rescue_from(ActionController::UnpermittedParameters) do |parameter_unpermitted_exception|
+        render :text => "Unpermitted parameter: #{parameter_unpermitted_exception}", :status => :bad_request
+      end
     end
 
     def params


### PR DESCRIPTION
Should we rescue UnpermittedParameters the same way as ParameterMissing? It is cleaner to return as bad request with a meaningful response body rather than raise error in the system.

It shines when you try to build API for services using strong parameters.
