### PR TITLE
Bug fix : nested ActiveSupport::HashWithIndifferentAccess were not converted to ActionController::Params

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -41,6 +41,21 @@ module ActionController
       @permitted = false
     end
 
+    def self.new_from_hash_copying_default(hash)
+      new(hash).tap do |new_hash|
+        new_hash.default = hash.default
+      end
+    end
+
+    def update(other_hash)
+      if other_hash.is_a? Parameters
+        super(other_hash)
+      else
+        other_hash.each_pair { |key, value| regular_writer(convert_key(key), convert_value(value)) }
+        self
+      end
+    end
+
     def permit!
       each_pair do |key, value|
         convert_hashes_to_parameters(key, value)
@@ -99,7 +114,7 @@ module ActionController
 
     protected
       def convert_value(value)
-        if value.class == Hash
+        if value.is_a?(Hash)
           self.class.new_from_hash_copying_default(value)
         elsif value.is_a?(Array)
           value.dup.replace(value.map { |e| convert_value(e) })

--- a/test/parameters_conversion_test.rb
+++ b/test/parameters_conversion_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+require 'action_controller/parameters'
+
+class ParametersConversionTest < ActiveSupport::TestCase
+
+  test "nested ActiveSupport::HashWithIndifferentAccess are converted to ActionController::Parameters" do
+    parameters  = ActionController::Parameters.new({:people => [{:a => 'b'}]}.with_indifferent_access)
+    assert_instance_of( ActionController::Parameters,
+                        parameters[:people].first)
+  end
+
+end


### PR DESCRIPTION
There is a bug when `params` is including nested hashes. The following should raise an `ActiveModel::ForbiddenAttributes exception` but don't:

```
class PeopleController < ApplicationController
  def create
    # params = {people: [{name: 'John Connor'},{name: 'Sarah Connor'},...]}
    @people = Person.create params[:people]
    ...
  end
end
```

Explanation:
1. `request.parameters` is first converted in  `ActiveSupport::HashWithIndifferentAccess` and so for all nested hashes.
2. Then `ActionController::Parameters.new(request.parameters)` should convert the params hash and nested ones to `ActionController::Parameters`.
   
   **==> The bug was that nested `ActiveSupport::HashWithIndifferentAccess` were not converted.**
