### PR TITLE
Ensure that the key in require is valid.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -52,7 +52,11 @@ module ActionController
     end
 
     def require(key)
-      self[key].presence || raise(ActionController::ParameterMissing.new(key))
+      if self[key].present? && (self[key].is_a?(ActionController::Parameters) || permitted_scalar?(self[key]))
+        self[key]
+      else
+        raise(ActionController::ParameterMissing.new(key))
+      end
     end
 
     alias :required :require

--- a/test/action_controller_required_params_test.rb
+++ b/test/action_controller_required_params_test.rb
@@ -18,6 +18,11 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     assert_response :bad_request
   end
 
+  test "required parameters in wrong format will raise exception" do
+    post :create, { :book => [ { :title => "Mjallo!" } ] }
+    assert_response :bad_request
+  end
+
   test "required parameters that are present will not raise" do
     post :create, { :book => { :name => "Mjallo!" } }
     assert_response :ok


### PR DESCRIPTION
A proof of concept of ensuring that the key returned from require is valid. Can use from refactoring if this is a feature we want to accept.

This is to get around a NoMethod exception raised by valid JSON, but invalid input as explained in issue #140
