### PR TITLE
Change default behavior to raise for extra params

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ params.require(:post).permit(:title)
 
 ## Handling of Unpermitted Keys
 
-By default parameter keys that are not explicitly permitted will be logged in the development and test environment. In other environments these parameters will simply be filtered out and ignored.
+By default parameter keys that are not explicitly permitted will cause errors to be raised in the development and test environment. In other environments these parameters will simply be filtered out and ignored.
 
-Additionally, this behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised.
+This behaviour can be changed by specifying the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised. If set to `false` the unpermitted attributes will be filtered out silently.
 
 ## Use Outside of Controllers
 

--- a/lib/strong_parameters/railtie.rb
+++ b/lib/strong_parameters/railtie.rb
@@ -10,7 +10,7 @@ module StrongParameters
 
     initializer "strong_parameters.config", :before => "action_controller.set_configs" do |app|
       ActionController::Parameters.action_on_unpermitted_parameters = app.config.action_controller.delete(:action_on_unpermitted_parameters) do
-        (Rails.env.test? || Rails.env.development?) ? :log : false
+        (Rails.env.test? || Rails.env.development?) ? :raise : false
       end
     end
   end


### PR DESCRIPTION
Catching potential problems early is really important for test driven
workflows and for rapid development cycles. By only logging in test and
development environments when un-permitted parameters are passed into the
controller, we open the door for confusion when a new parameter is
intentionally introduced but is quietly removed by strong_parameters.

This changes the default, unspecified behavior from logging extra parameters
to raising errors for them.
