### PR TITLE
Adjust handling of nil parameter for permitted hash.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -179,8 +179,6 @@ module ActionController
 
         # Slicing filters out non-declared keys.
         slice(*filter.keys).each do |key, value|
-          return unless value
-
           if filter[key] == []
             # Declaration {:comment_ids => []}.
             array_of_permitted_scalars_filter(params, key)

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -252,6 +252,16 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_nil permitted[:book][:genre]
   end
 
+  test "nil param value that should be a hash" do
+    params = ActionController::Parameters.new({
+      :book => nil
+    })
+    permitted = params.permit :book => { :genre => :type }
+
+    assert permitted.has_key?(:book)
+    assert_nil permitted[:book]
+  end
+
   test "fields_for_style_nested_params" do
     params = ActionController::Parameters.new({
       :book => {


### PR DESCRIPTION
When a nil param value arrives in place of an expected hash, return :key => nil, not simply nil.

Prior:

``` ruby
> params
=> {"book"=>nil}
> params.permit :book => { :genre => :type }
=> {}
```

Now:

``` ruby
> params
=> {"book"=>nil}
> params.permit :book => { :genre => :type }
=> {"book"=>nil}
```

Note: This is a redo of https://github.com/rails/strong_parameters/pull/20. I will close that PR.
