### PR TITLE
Change readme code examples to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ With this plugin Action Controller parameters are forbidden to be used in Active
 
 In addition, parameters can be marked as required and flow through a predefined raise/rescue flow to end up as a 400 Bad Request with no effort.
 
+
 ``` ruby
 class PeopleController < ActionController::Base
-  # This will raise an ActiveModel::ForbiddenAttributes exception because it's using mass assignment
-  # without an explicit permit step.
   def create
     Person.create(params[:person])
   end
+end
+```
+This will raise an ActiveModel::ForbiddenAttributes exception because it's using mass assignment without an explicit permit step.
 
-  # This will pass with flying colors as long as there's a person key in the parameters, otherwise
-  # it'll raise a ActionController::MissingParameter exception, which will get caught by
-  # ActionController::Base and turned into that 400 Bad Request reply.
-  def update
-    person = current_account.people.find(params[:id])
-    person.update_attributes!(person_params)
-    redirect_to person
+
+``` ruby 
+class PeopleController < ActionController::Base
+  def create
+    Person.create(person_params)
   end
 
   private
@@ -31,6 +31,7 @@ class PeopleController < ActionController::Base
     end
 end
 ```
+This will pass with flying colors as long as there's a person key in the parameters, otherwise it'll raise a ActionController::MissingParameter exception, which will get caught by ActionController::Base and turned into that 400 Bad Request reply.
 
 ## Permitted Scalar Values
 


### PR DESCRIPTION
Updating readme to show the two different examples more explicitly.  The previous code example was confusing to me.
