### PR TITLE
Params.fetch covers up any KeyError raised in block.

### DIFF
--- a/test/parameters_basic_test.rb
+++ b/test/parameters_basic_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+require 'action_controller/parameters'
+
+class BasicParametersTest < ActiveSupport::TestCase
+  test 'KeyError in fetch block should not be coverd up' do
+    params = ActionController::Parameters.new()
+    err = assert_raises(KeyError){
+      params.fetch(:missing_key){ raise(KeyError, "key not found: :also_missing") }
+    }
+    assert_match /also_missing/, err.message
+  end
+end


### PR DESCRIPTION
## What?

Given:

```
params = ActionController::Parameters.new()
params.fetch(:missing_key) { some.default_action( :that_raises, KeyError ) }
```

I would expect to see the `KeyError` from the block, not a `ActionController::ParameterMissing` exception for `:missing_key`.
## Why?

To ease in debugging one should not cover relevant exceptions. In this case the error is not that the requested key is missing and therefore the presented error message is a lie :)
## Fix

Not implemented yet, I wanted to get some comments **before** coding this time. I'd guess we'd have to fix the rescue line in action_controller/parameters.rb line 83. Suggestions on how are welcome.

If this is something we want just let me know and I'll fix it.
