### PR TITLE
Exception thrown is ActionController::ParameterMissing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ class PeopleController < ActionController::Base
   end
 
   # This will pass with flying colors as long as there's a person key in the parameters, otherwise
-  # it'll raise a ActionController::MissingParameter exception, which will get caught by
+  # it'll raise a ActionController::ParameterMissing exception, which will get caught by
   # ActionController::Base and turned into that 400 Bad Request reply.
   def update
     person = current_account.people.find(params[:id])


### PR DESCRIPTION
The exception thrown when a parameter is missing is an `ActionController::ParameterMissing` exception, not an `ActionController::MissingParameter` exception.
