### PR TITLE
Permit list of keys as array

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -60,7 +60,7 @@ module ActionController
     def permit(*filters)
       params = self.class.new
 
-      filters.each do |filter|
+      filters.flatten.each do |filter|
         case filter
         when Symbol, String
           permitted_scalar_filter(params, filter)

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -318,4 +318,12 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['0'][0]
     assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['1'][0]
   end
+
+  # --- permit array of keys ---------------------------------------------------
+
+  test "permitting parameters as an array" do
+    params = ActionController::Parameters.new(:id => :something)
+
+    refute params.permit([ :id ]).empty?, "array of keys has not been recognized"
+  end
 end

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -325,5 +325,6 @@ class NestedParametersTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(:id => :something)
 
     refute params.permit([ :id ]).empty?, "array of keys has not been recognized"
+    assert_equal :something, params.permit([ :id ])[:id]
   end
 end


### PR DESCRIPTION
To match [rails 4 implementation](https://github.com/rails/rails/commit/954c350daf435017e34327c83d877377c3f83778). I just bumped into this using strong-parameters with devise and rails 3.2
