### PR TITLE
Strong parameters should permit nested number as key. Fixes Rails Issue 12293.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -202,13 +202,17 @@ module ActionController
         if value.is_a?(Array)
           value.map { |el| yield el }.compact
           # fields_for on an array of records uses numeric hash keys.
-        elsif value.is_a?(Hash) && value.keys.all? { |k| k =~ /\A-?\d+\z/ }
+        elsif fields_for_style?(value)
           hash = value.class.new
           value.each { |k,v| hash[k] = yield(v, k) }
           hash
         else
           yield value
         end
+      end
+
+      def fields_for_style?(object)
+        object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
       end
 
       def unpermitted_parameters!(params)  

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -318,4 +318,19 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_equal 'William Shakespeare', permitted[:book][:authors_attributes]['0'][0]
     assert_equal 'Unattributed Assistant', permitted[:book][:authors_attributes]['1'][0]
   end
+
+  test "nested number as key" do
+    params = ActionController::Parameters.new({
+      product: {
+        properties: {
+          '0' => "prop0",
+          '1' => "prop1"
+        }
+      }
+    })
+    params = params.require(:product).permit(:properties => ["0"])
+    assert_not_nil        params[:properties]["0"]
+    assert_nil            params[:properties]["1"]
+    assert_equal "prop0", params[:properties]["0"]
+  end
 end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/12354.

Strong parameters should permit nested number as key.
Fields for style presume a value to be hash.
But a value sometimes is string.
