### PR TITLE
Fix fetch and add unit test.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -29,7 +29,7 @@ module ActionController
   class Parameters < ActiveSupport::HashWithIndifferentAccess
     attr_accessor :permitted
     alias :permitted? :permitted
-    
+
     cattr_accessor :action_on_unpermitted_parameters, :instance_accessor => false
 
     # Never raise an UnpermittedParameters exception because of these params
@@ -79,7 +79,8 @@ module ActionController
     end
 
     def fetch(key, *args)
-      convert_hashes_to_parameters(key, super)
+      return self[key] if has_key?(key)
+      super
     rescue KeyError, IndexError
       raise ActionController::ParameterMissing.new(key)
     end
@@ -215,23 +216,23 @@ module ActionController
         object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
       end
 
-      def unpermitted_parameters!(params)  
+      def unpermitted_parameters!(params)
         return unless self.class.action_on_unpermitted_parameters
-        
+
         unpermitted_keys = unpermitted_keys(params)
 
-        if unpermitted_keys.any?  
-          case self.class.action_on_unpermitted_parameters  
+        if unpermitted_keys.any?
+          case self.class.action_on_unpermitted_parameters
           when :log
             name = "unpermitted_parameters.action_controller"
             ActiveSupport::Notifications.instrument(name, :keys => unpermitted_keys)
-          when :raise  
-            raise ActionController::UnpermittedParameters.new(unpermitted_keys)  
-          end  
-        end  
-      end  
-  
-      def unpermitted_keys(params)  
+          when :raise
+            raise ActionController::UnpermittedParameters.new(unpermitted_keys)
+          end
+        end
+      end
+
+      def unpermitted_keys(params)
         self.keys - params.keys - NEVER_UNPERMITTED_PARAMS
       end
   end

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -22,6 +22,17 @@ class ParametersTaintTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch doesnt modify original hash if there is a default" do
+    assert_nothing_raised do
+      assert_equal "monkey", @params.fetch(:foo, "monkey")
+      assert_nil @params[:foo]
+      assert_equal "monkey", @params.fetch(:foo) { "monkey" }
+      assert_nil @params[:foo]
+      assert_equal({ :bar => "monkey" }, @params.fetch(:foo, :bar => "monkey"))
+      assert_nil @params[:foo]
+    end
+  end
+
   test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?


### PR DESCRIPTION
Current behavior of `fetch` is incorrect if the default value passed is a hash.  This occurs because of the use of `convert_hashes_to_parameters`.  If the value passed to `convert_hashes_to_parameters` is a hash, this value will be converted to a `Parameters` hash and stored at `self[key]`.  This seems inconsistent with how default values works with regular hashes.

Also, looks like this file had a bunch of trailing whitespace...if you want a clean blame log I can resubmit the PR without the whitespace cleanup.
