### PR TITLE
Don't mutate the original object when using ActionController::Parameters#fetch

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -43,7 +43,7 @@ module ActionController
 
     def permit!
       each_pair do |key, value|
-        convert_hashes_to_parameters(key, value)
+        convert_hashes_to_parameters!(key, value)
         self[key].permit! if self[key].respond_to? :permit!
       end
 
@@ -75,7 +75,7 @@ module ActionController
     end
 
     def [](key)
-      convert_hashes_to_parameters(key, super)
+      convert_hashes_to_parameters!(key, super)
     end
 
     def fetch(key, *args)
@@ -110,12 +110,20 @@ module ActionController
 
     private
 
-      def convert_hashes_to_parameters(key, value)
+      def convert_hashes_to_parameters!(key, value)
         if value.is_a?(Parameters) || !value.is_a?(Hash)
           value
         else
           # Convert to Parameters on first access
           self[key] = self.class.new(value)
+        end
+      end
+
+      def convert_hashes_to_parameters(key, value)
+        if value.is_a?(Parameters) || !value.is_a?(Hash)
+          value
+        else
+          self.class.new(value)
         end
       end
 

--- a/test/parameters_taint_test.rb
+++ b/test/parameters_taint_test.rb
@@ -22,6 +22,12 @@ class ParametersTaintTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch doesn't mutates the original object" do
+    value = @params.fetch(:city, { name: 'Barcelona' })
+    assert_equal value, ActionController::Parameters.new(name: 'Barcelona')
+    assert @params[:city].nil?
+  end
+
   test "not permitted is sticky on accessors" do
     assert !@params.slice(:person).permitted?
     assert !@params[:person][:name].permitted?


### PR DESCRIPTION
The `ActionController::Parameters#fetch` doesn't work in the same way that Hash#fetch and mutates the original object, what may cause problems in some applications. This PR defines `ActionController::Parameters#convert_hashes_to_parameters!` having the same past behaviour but redefines `ActionController::Parameters#convert_hashes_to_parameters` to not mutate the original object.
