### PR TITLE
Permit ActionController::AnyParam on hashes

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -27,6 +27,8 @@ module ActionController
     end
   end
 
+  class AnyParam; end
+
   class Parameters < ActiveSupport::HashWithIndifferentAccess
     attr_accessor :permitted
     alias :permitted? :permitted
@@ -190,6 +192,11 @@ module ActionController
         # Slicing filters out non-declared keys.
         slice(*filter.keys).each do |key, value|
           next unless value
+
+          if filter[key] == ActionController::AnyParam
+            params[key] = value
+            return
+          end
 
           if filter[key] == []
             # Declaration {:comment_ids => []}.

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -346,4 +346,48 @@ class NestedParametersTest < ActiveSupport::TestCase
       assert !hash.permitted?
     end
   end
+
+  test 'any param permitted in the root' do
+    initial_hash = {
+      :book => {
+        :title => "Romeo and Juliet",
+        :authors => [{
+          :name => "William Shakespeare",
+          :born => "1564-04-26"
+        }]
+      }
+    }
+
+    params = ActionController::Parameters.new(initial_hash)
+
+    permitted = params.permit({ :book => ActionController::AnyParam })
+    assert_equal initial_hash.with_indifferent_access, permitted
+  end
+
+  test 'any param permitted in a nested hash' do
+    initial_hash = {
+      :book => {
+        :title => "Romeo and Juliet",
+        :authors => [{
+          :name => "William Shakespeare",
+          :born => "1564-04-26"
+        }]
+      }
+    }
+
+    params = ActionController::Parameters.new(initial_hash)
+    expected_hash = {
+      "book" => {
+        "authors" => [
+          {
+            "name" =>  "William Shakespeare",
+            "born" => "1564-04-26"
+          }
+        ]
+      }
+    }
+
+    permitted = params.permit({ :book => [ authors: ActionController::AnyParam ] })
+    assert_equal expected_hash, permitted
+  end
 end


### PR DESCRIPTION
A way to support any args within a hash, for Rails APIs this is very useful
