### PR TITLE
allow optional inclusion in some controllers + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ By default parameter keys that are not explicitly permitted will be logged in th
 
 Additionally, this behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised.
 
+## Partial insclusion
+
+If you won't affect all controllers inherited from `ActionController::Base`,
+you can require this gem like this and include it manually
+
+```ruby
+gem 'strong_parameters', require: ['strong_parameters/requires']
+
+class SomeController < ActionController::Base
+  include ActionController::StrongParameters
+  ...
+```
+
 ## Use Outside of Controllers
 
 While Strong Parameters will enforce permitted and required values in your application controllers, keep in mind

--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -265,4 +265,3 @@ module ActionController
   end
 end
 
-ActiveSupport.on_load(:action_controller) { include ActionController::StrongParameters }

--- a/lib/strong_parameters.rb
+++ b/lib/strong_parameters.rb
@@ -1,4 +1,5 @@
-require 'action_controller/parameters'
-require 'active_model/forbidden_attributes_protection'
-require 'strong_parameters/railtie'
-require 'strong_parameters/log_subscriber'
+require 'strong_parameters/requires'
+require 'active_support'
+
+ActiveSupport.on_load(:action_controller) { include ActionController::StrongParameters }
+

--- a/lib/strong_parameters/requires.rb
+++ b/lib/strong_parameters/requires.rb
@@ -1,0 +1,5 @@
+require File.expand_path('../../action_controller/parameters', __FILE__)
+require File.expand_path('../../active_model/forbidden_attributes_protection', __FILE__)
+require 'strong_parameters/railtie'
+require 'strong_parameters/log_subscriber'
+


### PR DESCRIPTION
I've recently got a big legacy codebase, which I intend to upgrade, so this is quite inconvenient not to be able to include these gem only to some controllers.

I've also got use of #144 conserning ActiveSupport.on_load
