### PR TITLE
Use significant variable names for significant arguments

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -45,8 +45,8 @@ module ActionController
     def permit!
       each_pair do |key, value|
         value = convert_hashes_to_parameters(key, value)
-        Array.wrap(value).each do |_|
-          _.permit! if _.respond_to? :permit!
+        Array.wrap(value).each do |parameter|
+          parameter.permit! if parameter.respond_to? :permit!
         end
       end
 
@@ -121,7 +121,7 @@ module ActionController
 
       def convert_value_to_parameters(value)
         if value.is_a?(Array)
-          value.map { |_| convert_value_to_parameters(_) }
+          value.map { |v| convert_value_to_parameters(v) }
         elsif value.is_a?(Parameters) || !value.is_a?(Hash)
           value
         else


### PR DESCRIPTION
Per convention in Haskell, Go, Clojure, and more, an underscore is used as an unused argument/parameter name. Ruby 1.9 actually supports use of multiple instances of an underscore in a single argument list for this reason, and the [Github Ruby Styleguide](https://github.com/styleguide/ruby) encourages this usage.
