### PR TITLE
Using ActiveSupport#on_load instead of send :require to boot.

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -265,4 +265,4 @@ module ActionController
   end
 end
 
-ActionController::Base.send :include, ActionController::StrongParameters
+ActiveSupport.on_load(:action_controller) { include ActionController::StrongParameters }


### PR DESCRIPTION
This is similar to a [pull request I made](https://github.com/plataformatec/has_scope/pull/31/files) a while back on another project that included itself onto `ActionController`. In order for this to work on the `rails-api` gem, and other projects which may not use `ActionController::Base`, the method for including the `ActionController::StrongParameters` module should be changed.

``` ruby
# instead of...
ActionController::Base.send :include, ActionController::StrongParameters
# let's use...
ActiveSupport.on_load(:action_controller) { include ActionController::StrongParameters }
```

This is a redux of #144 without all the nasty whitespace mangling.
