### PR TITLE
Fixed integer keys in nested parameters

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -222,7 +222,7 @@ module ActionController
       end
 
       def fields_for_style?(object)
-        object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
+        object.is_a?(Hash) && object.all? { |k, v| k.to_s =~ /\A-?\d+\z/ && v.is_a?(Hash) }
       end
 
       def unpermitted_parameters!(params)  

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -346,4 +346,12 @@ class NestedParametersTest < ActiveSupport::TestCase
       assert !hash.permitted?
     end
   end
+
+  test 'that attributes key as integers works' do
+    params = ActionController::Parameters.new("test" => {"test_attributes" => {1 => {"id" => "id1"}}})
+    permitted = params.require(:test).permit(test_attributes: [:id])
+
+    assert_equal 1, permitted["test_attributes"].length
+    assert_equal "id1", permitted["test_attributes"][1]["id"]
+  end
 end

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -347,7 +347,7 @@ class NestedParametersTest < ActiveSupport::TestCase
     end
   end
 
-  test 'that attributes key as integers works' do
+  test 'that attribute keys as integers works' do
     params = ActionController::Parameters.new("test" => {"test_attributes" => {1 => {"id" => "id1"}}})
     permitted = params.require(:test).permit(test_attributes: [:id])
 


### PR DESCRIPTION
Fixed using integers as keys which is normal behaviour under Rails 3 in nested attributes-params.