### PR TITLE
Add possibility to trust a parameter branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ params.require(:token)
 params.require(:post).permit(:title)
 ```
 
+## Permitted parameter branches
+
+In some scenarios it can be useful to mark a branch of the parameter hash as trusted so that a key
+is just permitted independent from whether or not it's value is a scalar or matches a specific structure.
+You can express that trust like this:
+
+```
+params = ActionController::Parameters.new({
+  :id => 'foo',
+  :custom_json => {
+    :bar => 'baz',
+    :very => 'customizable'
+  }
+})
+params.permit({:custom_json => StrongParameters::ANY})
+
+# ==>
+# {:custom_json => {:bar => 'baz', :very => 'customizable'}}
+```
+
 ## Handling of Unpermitted Keys
 
 By default parameter keys that are not explicitly permitted will be logged in the development and test environment. In other environments these parameters will simply be filtered out and ignored.

--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -194,6 +194,9 @@ module ActionController
           if filter[key] == []
             # Declaration {:comment_ids => []}.
             array_of_permitted_scalars_filter(params, key)
+          elsif filter[key] == ::StrongParameters::ANY
+            # Declaration {:custom_json => :*} or {:custom_json => StrongParameters::ANY}
+            params[key] = value
           else
             # Declaration {:user => :name} or {:user => [:name, :age, {:adress => ...}]}.
             params[key] = each_element(value) do |element, index|

--- a/lib/strong_parameters.rb
+++ b/lib/strong_parameters.rb
@@ -1,4 +1,5 @@
 require 'action_controller/parameters'
 require 'active_model/forbidden_attributes_protection'
+require 'strong_parameters/any'
 require 'strong_parameters/railtie'
 require 'strong_parameters/log_subscriber'

--- a/lib/strong_parameters/any.rb
+++ b/lib/strong_parameters/any.rb
@@ -1,0 +1,3 @@
+module StrongParameters
+  ANY = :*
+end

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -346,4 +346,21 @@ class NestedParametersTest < ActiveSupport::TestCase
       assert !hash.permitted?
     end
   end
+
+  test "trusted values of nested parameters" do
+    params = ActionController::Parameters.new({
+      :resource => {
+        :id => 'foo',
+        :custom_json => {
+          :bar => 'baz',
+          :qux => {
+            quux: 1
+          }
+        }
+      }
+    })
+    permitted = params.permit(:resource => [{ :custom_json => StrongParameters::ANY }])
+    assert_nil permitted[:resource][:id]
+    assert_not_nil permitted[:resource][:custom_json]
+  end
 end


### PR DESCRIPTION
This change introduces a way to mark a specific branch of the parameter
hash as trusted. Using the added `StrongParameters::ANY` or `:*` allows
to mark a value of the hash respectively.

This functionality can be handy when your controllers already rely on
strong_parameters and raising of errors is enabled. If the parameter
hash contains in such a case a parameter value which is completely
customizable by the consumer of the controller, it might be impossible
to predefine keys.