### PR TITLE
fix: nested attributes with number as hash key now work

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -222,7 +222,7 @@ module ActionController
       end
 
       def fields_for_style?(object)
-        object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
+        object.is_a?(Hash) && object.all? { |k, v| k.to_s =~ /\A-?\d+\z/ && v.is_a?(Hash) }
       end
 
       def unpermitted_parameters!(params)  

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -282,6 +282,23 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_filtered_out permitted[:book][:authors_attributes]['0'], :age_of_death
   end
 
+  test "fields_for_style_nested_params when key is number" do
+    params = ActionController::Parameters.new({
+      :book => {
+        :authors_attributes => {
+          0 => { :name => 'William Shakespeare', :age_of_death => '52' }
+        }
+      }
+    })
+    permitted = params.permit :book => { :authors_attributes => [ :name ] }
+
+    assert_not_nil permitted[:book][:authors_attributes][0]
+    assert_equal 'William Shakespeare', permitted[:book][:authors_attributes][0][:name]
+
+    assert_filtered_out permitted[:book][:authors_attributes][0], :age_of_death
+  end
+
+
   test "fields_for_style_nested_params with negative numbers" do
     params = ActionController::Parameters.new({
       :book => {


### PR DESCRIPTION
This code works ok
```
ActionController::Parameters.new({"0" => {:subject_id=>45542597, :quantity=>1}}).permit([:subject_id, :quantity])
=> {:subject_id=>45542597, :quantity=>1}
```
expect number hash key to works ok too, but
```
ActionController::Parameters.new({0 => {:subject_id=>45542597, :quantity=>1}}).permit([:subject_id, :quantity])
=> {}
```