### PR TITLE
Ensure arrays of permitted values are supported

### DIFF
--- a/lib/action_controller/parameters.rb
+++ b/lib/action_controller/parameters.rb
@@ -63,7 +63,7 @@ module ActionController
     def permit(*filters)
       params = self.class.new
 
-      filters.each do |filter|
+      filters.flatten.each do |filter|
         case filter
         when Symbol, String
           permitted_scalar_filter(params, filter)

--- a/test/parameters_permit_test.rb
+++ b/test/parameters_permit_test.rb
@@ -104,6 +104,12 @@ class NestedParametersTest < ActiveSupport::TestCase
     assert_equal nil, permitted[:c]
   end
 
+  test 'permit parameters as an array' do
+    params = ActionController::Parameters.new(:foo => 'bar')
+
+    assert_equal 'bar', params.permit([:foo])[:foo]
+  end
+
   # --- key to empty array -----------------------------------------------------
 
   test 'key to empty array: empty arrays pass' do


### PR DESCRIPTION
This replicates behavior encountered in Rails 4.0 and up: https://github.com/rails/rails/blob/4-0-stable/actionpack/lib/action_controller/metal/strong_parameters.rb#L266

Without this change, the following snippets fails with arrays, which is permitted in Rails 4:

```rb
> p = ActionController::Parameters.new({ user: { name: "foo", email: "foo@bar.com" } })
=> {"user"=>{"name"=>"foo", "email"=>"foo@bar.com"}}

> p.require(:user).permit(:name, :email)
=> {"name"=>"foo", "email"=>"foo@bar.com"}

> p.require(:user).permit([:name, :email])
[2016-11-10 17:38:08] DEBUG ActiveSupport::Configurable::Configuration {}: Unpermitted parameters: name, email
=> {}
```

Using with an array now works the same way than spread arguments and allows for easier upgrade from Rails 3 to 4.