### PR TITLE
Document third option for `action_on_unpermitted_parameters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ params.require(:post).permit(:title)
 
 By default parameter keys that are not explicitly permitted will be logged in the development and test environment. In other environments these parameters will simply be filtered out and ignored.
 
-Additionally, this behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised.
+This behaviour can be changed by changing the `config.action_controller.action_on_unpermitted_parameters` property in your environment files. If set to `:log` the unpermitted attributes will be logged, if set to `:raise` an exception will be raised, and if set to `false` unpermitted attributes will be filtered out and ignored.
 
 ## Use Outside of Controllers
 


### PR DESCRIPTION
I was researching on `config.action_controller.action_on_unpermitted_parameters` and couldn't immediately see how I end up with the default setting for e.g. production, that simply ignores unpermitted attributes and filters them out. I've now addressed this in the README, hope that it's useful!